### PR TITLE
Fix wrong import in pre-persist-listener.md

### DIFF
--- a/Resources/doc/pre-persist-listener.md
+++ b/Resources/doc/pre-persist-listener.md
@@ -13,7 +13,7 @@ When using the default **doctrine logger**, you may want to add customized data 
 
 namespace  MyProject\MyBundle\Listener;
 
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Doctrine\ORM\Event\LifecycleEventArgs;
 
 class AuditLogPrePersistListener
 {


### PR DESCRIPTION
ContainerAware interface was imported instead of LifecycleEventArgs