### PR TITLE
Update logger.yml to convert private service to public service as required by Symfony

### DIFF
--- a/Resources/config/default/logger.yml
+++ b/Resources/config/default/logger.yml
@@ -9,6 +9,6 @@ services:
   xiidea.easy_audit.entity_delete_event.subscriber:
           class: Xiidea\EasyAuditBundle\Subscriber\DoctrineDeleteEventLogger
           arguments: ['@xiidea.easy_audit.logger.service']
-          public: false
+          public: true
           tags:
               - { name: kernel.event_subscriber }


### PR DESCRIPTION
Received the error:

The service "xiidea.easy_audit.entity_delete_event.subscriber" must be public as event subscribers are lazy-loaded.  

Upon the latest update to Symfony 2.8 LTS. 
